### PR TITLE
added loading message with instruction on how to move the bar

### DIFF
--- a/cooline.lua
+++ b/cooline.lua
@@ -321,6 +321,8 @@ function cooline.VARIABLES_LOADED()
 	cooline:RegisterEvent('BAG_UPDATE_COOLDOWN')
 	
 	cooline.detect_cooldowns()
+
+	DEFAULT_CHAT_FRAME:AddMessage('|c00ffff00' .. COOLINE_LOADED_MESSAGE .. '|r');
 end
 
 function cooline.BAG_UPDATE_COOLDOWN()

--- a/settings.lua
+++ b/settings.lua
@@ -23,3 +23,5 @@ cooline_theme = {
 cooline_ignore_list = {
 	'hearthstone'
 }
+
+COOLINE_LOADED_MESSAGE = 'Cooline loaded: move the location of the cooline bar by holding <alt> while dragging it with left mouse button.'


### PR DESCRIPTION
I spent a long time trying to figure out how to move the bar. I ended up having to look through the code and see that it's only dragable when the alt key is held down:

```lua
cooline:SetScript('OnUpdate', function()
    this:EnableMouse(IsAltKeyDown())
    if not IsAltKeyDown() and this.dragging then
        this:on_drag_stop()
    end
    cooline.on_update()
end)
```

This commit just adds a message with instructions on how to move the bar when the addon loads (like many other addons do).